### PR TITLE
QueueService now assigns database ID for simulation. Returns to user in Talend after sending simulation input.

### DIFF
--- a/src/main/java/com/example/queueservice_batterysim/Controller/MessageJsonController.java
+++ b/src/main/java/com/example/queueservice_batterysim/Controller/MessageJsonController.java
@@ -9,13 +9,16 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/queue")
 public class MessageJsonController {
     private RabbitMQJsonProducer jsonProducer;
+    private long uniqueId = 0;
+
     public MessageJsonController(RabbitMQJsonProducer jsonProducer) {
         this.jsonProducer = jsonProducer;
     }
     @PostMapping("/publish")
     public ResponseEntity<String> sendJsonMessage(@RequestBody BatterySimMessage simMessage){
+        simMessage.setId(++uniqueId);
         jsonProducer.sendJsonMessage(simMessage);
-        return ResponseEntity.ok("Json Message Sent to RabbitMQ ...");
+        return ResponseEntity.ok("Simulation Data sent to Rabbit MQ. \nYour simulation ID is: " + simMessage.getId());
     }
 }
 

--- a/src/main/java/com/example/queueservice_batterysim/dto/BatterySimMessage.java
+++ b/src/main/java/com/example/queueservice_batterysim/dto/BatterySimMessage.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class BatterySimMessage {
-    private String id;
+    private Long id;
     private String simulationType;
     private double time;
     private double upperVoltage;


### PR DESCRIPTION
QueueService now assigns the unique ID (gimmicky but the simplest I could get to work) and sends that ID back to the user in Talend. Now they have their ID to search the database endpoint.